### PR TITLE
Inject soap client factory instead of an instance of SoapClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ use Setono\GLS\Webservice\Client\Client;
 use Setono\GLS\Webservice\Factory\SoapClientFactory;
 use Setono\GLS\Webservice\Model\ParcelShop;
 
-$factory = new SoapClientFactory('https://www.gls.dk/webservices_v4/wsShopFinder.asmx?WSDL');
-
-$client = new Client($factory->create());
+$client = new Client(new SoapClientFactory('https://www.gls.dk/webservices_v4/wsShopFinder.asmx?WSDL'));
 
 /** @var ParcelShop[] $parcelShops */
 $parcelShops = $client->searchNearestParcelShops('Street', '12313', 'DK');

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -23,10 +23,13 @@
       <code>$result-&gt;SearchNearestParcelShopsResult-&gt;parcelshops</code>
     </MixedPropertyFetch>
     <PossiblyNullArgument occurrences="3">
-      <code>$this-&gt;soapClient-&gt;__getLastResponse()</code>
-      <code>$this-&gt;soapClient-&gt;__getLastResponse()</code>
-      <code>$this-&gt;soapClient-&gt;__getLastResponseHeaders()</code>
+      <code>$soapClient-&gt;__getLastResponse()</code>
+      <code>$soapClient-&gt;__getLastResponse()</code>
+      <code>$soapClient-&gt;__getLastResponseHeaders()</code>
     </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="1">
+      <code>__getLastResponseHeaders</code>
+    </PossiblyNullReference>
     <UnnecessaryVarAnnotation occurrences="1">
       <code>string|null</code>
     </UnnecessaryVarAnnotation>

--- a/src/Client/ClientInterface.php
+++ b/src/Client/ClientInterface.php
@@ -24,8 +24,6 @@ interface ClientInterface
     /**
      * Get one ParcelShop.
      *
-     *
-     *
      * @throws ParcelShopNotFoundException
      */
     public function getOneParcelShop(string $parcelShopNumber): ParcelShop;
@@ -53,7 +51,6 @@ interface ClientInterface
      *
      * NOTICE: It looks like (judging by the returned results) this returns the same results as getParcelShopDropPoint
      * but GLS' IT support does not know, so the safest bet is to use this method because this is the one they recommend
-     *
      *
      * @return ParcelShop[]
      */

--- a/src/Factory/SoapClientFactory.php
+++ b/src/Factory/SoapClientFactory.php
@@ -10,18 +10,24 @@ final class SoapClientFactory implements SoapClientFactoryInterface
 {
     private string $wsdl;
 
-    public function __construct(string $wsdl)
+    /** @var array<string, mixed> */
+    private array $defaultOptions;
+
+    /**
+     * @param array<string, mixed> $defaultOptions
+     */
+    public function __construct(string $wsdl, array $defaultOptions = [])
     {
         $this->wsdl = $wsdl;
+
+        $this->defaultOptions = array_merge([
+            'trace' => true,
+            'exceptions' => true,
+        ], $defaultOptions);
     }
 
     public function create(array $options = []): SoapClient
     {
-        $options = array_merge([
-            'trace' => true,
-            'exceptions' => true,
-        ], $options);
-
-        return new SoapClient($this->wsdl, $options);
+        return new SoapClient($this->wsdl, array_merge($this->defaultOptions, $options));
     }
 }


### PR DESCRIPTION
This PR is a BC break.

Instead of injecting an instance of `SoapClient` into the `Client` we inject the `SoapClientFactoryInterface`. This has the advantage that the `SoapClient` doesn't have to be instantiated in order to instantiate the `Client`.